### PR TITLE
fix: break infinite loop in `package.json` search in Python projects

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.2.3-0",
+  "version": "4.2.3-1",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -136,6 +136,7 @@ export function loadPackageJsonAndDocs(
 	}
 
 	if(!found) {
+		// TODO: load the actual package information from pyproject.toml or similar
 		return {
 			packageJson: {
 				name: 'crawlee',

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -124,9 +124,26 @@ export function loadPackageJsonAndDocs(
 	changelogFileName: string = 'CHANGELOG.md',
 ) {
 	let currentDir = initialDir;
+	let found = true;
 
 	while (!fs.existsSync(path.join(currentDir, pkgFileName))) {
-		currentDir = path.dirname(currentDir);
+		if (currentDir === path.dirname(currentDir)) {
+			found = false;
+			break;
+		} else {
+			currentDir = path.dirname(currentDir);
+		}
+	}
+
+	if(!found) {
+		return {
+			packageJson: {
+				name: 'crawlee',
+				version: '1.0.0',
+			},
+			readmePath: '',
+			changelogPath: '',
+		}
 	}
 
 	const readmePath = path.join(currentDir, readmeFileName);


### PR DESCRIPTION
Fixes the infinite loop on Docusaurus build if no `package.json` file is found in the current filesystem branch.