### PR TITLE
fix: generate `sourceFileMap` even without `symbolIdMap`

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -355,10 +355,13 @@ function buildSourceFileNameMap(
 	const map: Record<string, boolean> = {};
 	const cwd = process.cwd();
 
-	Object.values(project.symbolIdMap).forEach((symbol) => {
-		// absolute
-		map[path.normalize(path.join(cwd, symbol.sourceFileName))] = true;
-	});
+	if(project.symbolIdMap) {
+		Object.values(project.symbolIdMap).forEach((symbol) => {
+			// absolute
+			map[path.normalize(path.join(cwd, symbol.sourceFileName))] = true;
+		});
+	}
+
 
 	modChildren.forEach((child) => {
 		child.sources?.forEach((sf) => {


### PR DESCRIPTION
Older plugin versions seem to have generated `api-typedoc.json` files without the `symbolIdMap` property. These are now stored in the `versioned-docs` folders in our projects and are blocking update to `4.x.x` versions of this package.

This PR checks for the `symbolIdMap` property before trying to access it. 