### PR TITLE
fix: defensive defaults when looking for package entrypoints

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -286,7 +286,7 @@ function modContainsEntryPoint(
 	// They also don't use full paths like "package/src/index.ts" and simply use "index.ts",
 	// so account for those entry points also.
 	if (!relModSourceFile) {
-		const absEntryPoint = path.normalize(path.join(meta.packageRoot, entry.path));
+		const absEntryPoint = path.normalize(path.join(meta.packageRoot ?? '', entry.path ?? ''));
 		const relEntryPointName = path.basename(relEntryPoint);
 		const entryPointInSourceFiles =
 			!!meta.allSourceFiles[absEntryPoint] ||


### PR DESCRIPTION
Some `package.json` configurations can cause the script to fail with empty `meta.packageRoot`. To avoid type problems, we use nullish coalescing to set the path to `''` if the property is not present.