### PR TITLE
feat: render default values for arrays correctly

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/components/Type.tsx
+++ b/packages/plugin/src/components/Type.tsx
@@ -52,7 +52,15 @@ export function Type({ needsParens = false, type: base }: TypeProps) {
 	// https://github.com/TypeStrong/typedoc/blob/master/src/lib/output/themes/default/partials/type.tsx
 	switch (String(base.type)) {
 		case 'array': {
-			const type = base as JSONOutput.ArrayType;
+			const type = base as JSONOutput.ArrayType & { value?: JSONOutput.SomeType };
+
+			// If the array provides a non-empty "value" property, it's likely the default value of the array we want to render.
+			if (type.value) {
+				// eslint-disable-next-line
+				type.type = 'literal' as any;
+
+				return <Type type={type} />;
+			}
 
 			return (
 				<>

--- a/playground/js/src/bar.ts
+++ b/playground/js/src/bar.ts
@@ -11,6 +11,18 @@ export interface BarOptions {
      * @default 0
      */
     age: number;
+    /**
+     * Favourite numbers of the `Bar` instance.
+     * 
+     * @default [1, 2, Infinity]
+     */
+    numbers: number[];
+    /**
+     * Favourite words of the `Bar` instance.
+     * 
+     * @default ['foo', 'bar', 'jabberwocky']
+     */
+    strings: string[];
 }
 
 /**


### PR DESCRIPTION
Fixes the `number[]` issue from https://github.com/apify/crawlee/issues/2266 - the `@default` value for arrays was rendered as a basic array type and the `@default` decorator wasn't used.

When `value` is set in the array type, the value is rendered as a literal type.