### PR TITLE
chore: fix packemon build

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -32,7 +32,8 @@
       "@theme/*",
       "@docusaurus/*",
       "@vscode/*",
-      "css$"
+      "css$",
+      "cheerio*"
     ]
   },
   "peerDependencies": {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.2.11-0",
+  "version": "4.2.11-1",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",


### PR DESCRIPTION
Sets the new `cheerio` dependency as an `external`, so it doesn't get packed into the release bundle.