### PR TITLE
fix: separate module for `ApiOptionsContext`

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/components/ApiItem.tsx
+++ b/packages/plugin/src/components/ApiItem.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { createContext, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { PageMetadata } from '@docusaurus/theme-common';
 import type { DocusaurusConfig } from '@docusaurus/types';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -11,6 +11,7 @@ import type { TOCItem, TSDDeclarationReflection, TSDDeclarationReflectionMap } f
 import { escapeMdx } from '../utils/helpers';
 import { getKindIconHtml } from '../utils/icons';
 import ApiItemLayout from './ApiItemLayout';
+import { ApiOptionsContext } from './ApiOptionsContext';
 import { displayPartsToMarkdown } from './Comment';
 import { Flags } from './Flags';
 import { Reflection } from './Reflection';
@@ -57,11 +58,6 @@ function extractTOC(
 export interface ApiItemProps extends Pick<DocItemProps, 'route'> {
 	readme?: React.ComponentType;
 }
-
-export const ApiOptionsContext = createContext({
-	hideInherited: false,
-	setHideInherited: (hideInherited: boolean) => {},
-});
 
 // Recursively traverse the passed object. If the object has a `sources` property, resolve the GitHub URLs.
 function resolveGithubUrls(obj: { sources?: { url?: string; fileName: string; line: number; character: number }[] }, siteConfig: DocusaurusConfig, gitRefName: string) {

--- a/packages/plugin/src/components/ApiOptionsContext.tsx
+++ b/packages/plugin/src/components/ApiOptionsContext.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/jsx-filename-extension */
+import { createContext } from "react";
+
+export const ApiOptionsContext = createContext({
+	hideInherited: false,
+	setHideInherited: (hideInherited: boolean) => {},
+});

--- a/packages/plugin/src/components/ApiOptionsLayout.tsx
+++ b/packages/plugin/src/components/ApiOptionsLayout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from 'react';
-import { ApiOptionsContext } from './ApiItem';
+import { ApiOptionsContext } from './ApiOptionsContext';
 
 export default function ApiOptionsLayout({ className }: { className: string }) {
 	const { hideInherited, setHideInherited } = useContext(ApiOptionsContext);

--- a/packages/plugin/src/components/Member.tsx
+++ b/packages/plugin/src/components/Member.tsx
@@ -7,7 +7,7 @@ import { useReflectionMap } from '../hooks/useReflectionMap';
 import { escapeMdx } from '../utils/helpers';
 import { hasOwnDocument } from '../utils/visibility';
 import { AnchorLink } from './AnchorLink';
-import { ApiOptionsContext } from './ApiItem';
+import { ApiOptionsContext } from './ApiOptionsContext';
 import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { Flags } from './Flags';
 import { MemberDeclaration } from './MemberDeclaration';


### PR DESCRIPTION
Trying to mitigate the `Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: [object].` React error, apparently originating in `ApiItem.tsx`. 

The occurrence of this error seems to be correlated with the latest upstream merge, adding `ApiOptionsContext`.