### PR TITLE
fix: resolve nested inheritance with topological ordering

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/plugin/python/inheritance.ts
+++ b/packages/plugin/src/plugin/python/inheritance.ts
@@ -1,80 +1,156 @@
 import type { TypeDocObject } from './types';
-import { getGroupName, getOID } from './utils';
+import { getGroupName, getOID, sortChildren } from './utils';
 
-/**
- * Given an ancestor and a descendant objects, injects the children of the ancestor into the descendant.
- *
- * Sets the `extendedTypes` / `extendedBy` properties.
- * @param ancestor
- * @param descendant
- */
-export function resolveInheritedSymbols(ancestor: TypeDocObject, descendant: TypeDocObject) {
-	descendant.children ??= [];
+export class InheritanceGraph {
+	private readonly nodes = new Map<TypeDocObject['name'], TypeDocObject>();
 
-	descendant.extendedTypes = [
-		...(descendant.extendedTypes ?? []),
-		{
-			name: ancestor.name,
-			target: ancestor.id,
-			type: 'reference',
-		},
-	];
+	private readonly childrenOf: Map<TypeDocObject['name'], TypeDocObject['name'][]> = new Map();
 
-	ancestor.extendedBy = [
-		...(ancestor.extendedBy ?? []),
-		{
-			name: descendant.name,
-			target: descendant.id,
-			type: 'reference',
-		},
-	];
+	/**
+	 * Adds a new inheritance relationship.
+	 * @param parentName
+	 * @param child
+	 */
+	addRelationship(parentName: TypeDocObject['name'], child: TypeDocObject) {
+		const children = this.childrenOf.get(parentName) ?? [];
 
-	for (const inheritedChild of ancestor.children ?? []) {
-		const ownChild = descendant.children?.find((x) => x.name === inheritedChild.name);
+		children.push(child.name);
+		this.childrenOf.set(parentName, children);
 
-		if (!ownChild) {
-			const childId = getOID();
+		this.nodes.set(child.name, child);
 
-			const { groupName } = getGroupName(inheritedChild);
-			if (!groupName) {
-				throw new Error(
-					`Couldn't resolve the group name for ${inheritedChild.name} (inherited child of ${ancestor.name})`,
-				);
-			}
+		this.registerNode(child);
+	}
 
-			const group = descendant.groups?.find((g) => g.title === groupName);
+	registerNode(node: TypeDocObject) {
+		this.nodes.set(node.name, node);
+	}
 
-			if (group) {
-				group.children.push(inheritedChild.id);
-			} else {
-				descendant.groups?.push({
-					children: [inheritedChild.id],
-					title: groupName,
-				});
-			}
+	/**
+	 * Resolves the inheritance relationships between the objects.
+	 * 
+	 * Adds the inherited symbols to the descendants, and sets the `extendedTypes` / `extendedBy` properties.
+	 * The symbol inheritance works transitively, so if `A` inherits from `B` and `B` inherits from `C`, then `A` inherits from `C`.
+	 *
+	 * The order of the inheritance is determined by the topological order of the inheritance graph (to ensure the ancestors are processed before the descendants).
+	 */
+	resolveInheritance() {
+		const objects = this.getTopologicalOrder();
 
-			descendant.children.push({
-				...inheritedChild,
-				id: childId,
-				inheritedFrom: {
-					name: `${ancestor.name}.${inheritedChild.name}`,
-					target: inheritedChild.id,
-					type: 'reference',
-				},
-			});
-		} else if (!ownChild.comment?.summary?.[0]?.text) {
-			ownChild.inheritedFrom = {
-				name: `${ancestor.name}.${inheritedChild.name}`,
-				target: inheritedChild.id,
-				type: 'reference',
-			};
+		for (const parent of objects) {
+			const children = this.childrenOf.get(parent.name);
 
-			for (const key of Object.keys(inheritedChild)) {
-				if (key !== 'id' && key !== 'inheritedFrom') {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-					ownChild[key as keyof typeof ownChild] = inheritedChild[key as keyof typeof inheritedChild];
+			if (children) {
+				for (const childId of children) {
+					const child = this.nodes.get(childId);
+
+					if (child) {
+						this.resolveInheritedSymbols(parent, child);
+					}
 				}
 			}
 		}
+	}
+
+	protected resolveInheritedSymbols(ancestor: TypeDocObject, descendant: TypeDocObject) {
+		descendant.children ??= [];
+	
+		descendant.extendedTypes = [
+			...(descendant.extendedTypes ?? []),
+			{
+				name: ancestor.name,
+				target: ancestor.id,
+				type: 'reference',
+			},
+		];
+	
+		ancestor.extendedBy = [
+			...(ancestor.extendedBy ?? []),
+			{
+				name: descendant.name,
+				target: descendant.id,
+				type: 'reference',
+			},
+		];
+	
+		for (const inheritedChild of ancestor.children ?? []) {
+			const ownChild = descendant.children?.find((x) => x.name === inheritedChild.name);
+	
+			if (!ownChild) {
+				const childId = getOID();
+	
+				const { groupName } = getGroupName(inheritedChild);
+				if (!groupName) {
+					throw new Error(
+						`Couldn't resolve the group name for ${inheritedChild.name} (inherited child of ${ancestor.name})`,
+					);
+				}
+	
+				const group = descendant.groups?.find((g) => g.title === groupName);
+	
+				if (group) {
+					group.children.push(inheritedChild.id);
+				} else {
+					descendant.groups?.push({
+						children: [inheritedChild.id],
+						title: groupName,
+					});
+				}
+	
+				descendant.children.push({
+					...inheritedChild,
+					id: childId,
+					inheritedFrom: {
+						name: `${ancestor.name}.${inheritedChild.name}`,
+						target: inheritedChild.id,
+						type: 'reference',
+					},
+				});
+			} else if (!ownChild.comment?.summary?.[0]?.text) {
+				ownChild.inheritedFrom = {
+					name: `${ancestor.name}.${inheritedChild.name}`,
+					target: inheritedChild.id,
+					type: 'reference',
+				};
+	
+				for (const key of Object.keys(inheritedChild)) {
+					if (key !== 'id' && key !== 'inheritedFrom') {
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						ownChild[key as keyof typeof ownChild] = inheritedChild[key as keyof typeof inheritedChild];
+					}
+				}
+			}
+		}
+
+		sortChildren(descendant);
+	}
+
+	protected getTopologicalOrder(): TypeDocObject[] {
+		const visited = new Set<TypeDocObject['name']>();
+		const stack: TypeDocObject[] = [];
+
+		const visit = (nodeName: TypeDocObject['name']) => {
+			if (visited.has(nodeName)) return;
+
+			const node = this.nodes.get(nodeName);
+
+			if (!node) {
+				throw new Error(`Couldn't find the node with the name ${nodeName}`);
+			}
+
+			visited.add(nodeName);
+
+			for (const child of this.childrenOf.get(nodeName) ?? []) {
+				visit(child);
+			}
+
+			stack.push(node);
+		};
+
+		for (const node of this.childrenOf.keys()) {
+			visit(node as TypeDocObject['name']);
+		}
+
+		return stack.reverse();
 	}
 }

--- a/packages/plugin/src/plugin/python/utils.ts
+++ b/packages/plugin/src/plugin/python/utils.ts
@@ -121,3 +121,23 @@ export function groupSort(g1: string, g2: string) {
 	}
 	return g1.localeCompare(g2);
 }
+
+/**
+ * Sorts the `groups` of `typedocMember` using {@link groupSort} and sorts the children of each group alphabetically.
+ */
+export function sortChildren(typedocMember: TypeDocObject) {
+	if (!typedocMember.groups) return;
+
+	for (const group of typedocMember.groups) {
+		group.children.sort((a, b) => {
+			const firstName =
+				typedocMember.children?.find((x) => x.id === a || x.inheritedFrom?.target === a)?.name ??
+				'a';
+			const secondName =
+				typedocMember.children?.find((x) => x.id === b || x.inheritedFrom?.target === b)?.name ??
+				'b';
+			return firstName.localeCompare(secondName);
+		});
+	}
+	typedocMember.groups?.sort((a, b) => groupSort(a.title, b.title));
+}

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -7,6 +7,7 @@
   "compilerOptions": {
     "lib": [
       "es2021"
-    ]
+    ],
+    "target": "ES2015"
   }
 }

--- a/playground/python/src/__init__.py
+++ b/playground/python/src/__init__.py
@@ -7,8 +7,6 @@ class Bar:
     class that prints "Bar" when it is initialized and "foo" when the foo method is called.
     """
 
-    foo = Foo()
-
     def __init__(self):
         """
         The constructor of the bar class.
@@ -20,3 +18,28 @@ class Bar:
         The foo method of the bar class, prints "foo".
         """
         print("foo")
+
+@docs_group('Classes')
+class BarBar(Bar):
+    """
+    The BarBar class inherits from the Bar class and prints "BarBar" when it is initialized.
+    """
+
+    def __init__(self):
+        """
+        The constructor of the bar class.
+        """
+        print("BarBar")
+
+@docs_group('Classes')
+class BarBarBar(BarBar):
+    """
+    The BarBarBar class inherits from the BarBar class and prints "BarBarBar" when it is initialized.
+    """
+
+    def __init__(self):
+        """
+        The constructor of the bar class.
+        """
+        print("BarBarBar")
+

--- a/playground/python/src/foo.py
+++ b/playground/python/src/foo.py
@@ -1,5 +1,5 @@
 @docs_group('Classes')
-class Foo:
+class Foo(BarBarBar):
     """
     The foo class is a simple class that prints "Foo" when it is initialized and "bar" when the bar method is called.
     """
@@ -24,3 +24,9 @@ class Foo:
         """
 
         print("bar", param)
+
+    def foo(self):
+        """
+        The foo method of the FOO class, prints "foo".
+        """
+        print("foo")


### PR DESCRIPTION
Uses DFS-based topological ordering to resolve the inherited symbols in the order of the inheritance, enabling indirectly inherited symbols (from `(grand)+parents`).