### PR TITLE
fix(python): ignore external ancestors during the inheritance resolution

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/plugin/python/inheritance.ts
+++ b/packages/plugin/src/plugin/python/inheritance.ts
@@ -150,7 +150,8 @@ export class InheritanceGraph {
 			const node = this.nodes.get(nodeName);
 
 			if (!node) {
-				throw new Error(`Couldn't find the node with the name ${nodeName}`);
+				// throw new Error(`Couldn't find the node with the name ${nodeName}`); // breaks the build for projects with external ancestors
+				return;
 			}
 
 			visited.add(nodeName);

--- a/playground/python/src/foo.py
+++ b/playground/python/src/foo.py
@@ -1,5 +1,5 @@
 @docs_group('Classes')
-class Foo(BarBarBar):
+class Foo(BarBarBar, Generic[T]):
     """
     The foo class is a simple class that prints "Foo" when it is initialized and "bar" when the bar method is called.
     """


### PR DESCRIPTION
Real-world projects often inherit from external symbols (`ABC`, `Generic` etc.). 

The documentation build shouldn't fail in those cases - it should just ignore those instead. 