### PR TITLE
fix(python): target the `Error` group predicate better

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/plugin/python/utils.ts
+++ b/packages/plugin/src/plugin/python/utils.ts
@@ -53,7 +53,7 @@ export function getGroupName(object: TypeDocObject): {
 			Boolean(['BaseModel', 'TypedDict'].some((base) =>
 				(x?.bases as { includes: (x: string) => boolean })?.includes(base),
 			) || x?.decorations?.some((d) => d.name === 'dataclass')),
-		Errors: (x) => x.name.toLowerCase().includes('error'),
+		Errors: (x) => x.name.toLowerCase().endsWith('error') && x.kindString === 'Class',
 		Classes: (x) => x.kindString === 'Class',
 		'Main Clients': (x) => ['ApifyClient', 'ApifyClientAsync'].includes(x.name),
 		'Async Resource Clients': (x) => x.name.toLowerCase().includes('async'),


### PR DESCRIPTION
The current predicate marks regular methods as errors (see below). In all of our codebase, the Error classes' names end with `Error`.

![obrazek](https://github.com/user-attachments/assets/0feeacec-8a1c-4813-81a7-afea2a5a955e)