### PR TITLE
fix: respect indentation in multiline Python comments

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/playground/python/src/__init__.py
+++ b/playground/python/src/__init__.py
@@ -13,11 +13,29 @@ class Bar:
         """
         print("Bar")
 
-    def foo(self) -> Foo:
+    def foo(self, count: int) -> Foo:
         """
         The foo method of the bar class, prints "foo".
+
+        Args:
+            count: The number of times to print "foo".
+                This comment is multiline, and contains
+                some urls too, look: https://apify.com
         """
-        print("foo")
+        print("foo " * count)
+    
+    def foo2(self, count: int, second_arg: str) -> Foo:
+        """
+        The foo2 method of the bar class, prints "foo2".
+
+        Args:
+            count: The number of times to print "foo2".
+                This comment is multiline, and contains some urls too,
+                look: https://apify.com
+            second_arg: The second argument. This shouldn't be a part of the previous argument's
+                description: even with a colon.
+        """
+        print("foo2 " * count)
 
 @docs_group('Classes')
 class BarBar(Bar):


### PR DESCRIPTION
Fixes cases when the docstring parser parses:

```
Args:
    first_param: has a multiline comment with a colon in the
        wrong: place
```

as `{ first_param: "has a multiline comment with a colon in the", wrong: "place" }`.

