### PR TITLE
fix: render `keyword-only` and `optional` pills consistently

### DIFF
--- a/packages/plugin/src/components/Flags.tsx
+++ b/packages/plugin/src/components/Flags.tsx
@@ -18,6 +18,7 @@ export function Flags({ flags }: FlagsProps) {
 	return (
 		<span className="tsd-flag-group">
 			{Object.keys(flags)
+				.filter((flag) => flags[flag])
 				.map(removePrefix)
 				.map((flag) => (
 					<span key={flag} className={`tsd-flag tsd-flag-${flag}`}>

--- a/packages/plugin/src/components/MemberSignatureTitle.tsx
+++ b/packages/plugin/src/components/MemberSignatureTitle.tsx
@@ -18,9 +18,8 @@ export function MemberSignatureTitle({ useArrow, hideName, sig }: MemberSignatur
 	const { isPython } = usePluginData('docusaurus-plugin-typedoc-api') as GlobalData;
 	// add `*` before the first keyword-only parameter
 	const parametersCopy = sig.parameters?.slice() ?? [];
-	const firstKeywordOnlyIndex = parametersCopy.findIndex((param) =>
-		Object.keys(param.flags).includes('keyword-only'),
-	);
+	const firstKeywordOnlyIndex = parametersCopy.findIndex((param) => param.flags['keyword-only']);
+
 	if (firstKeywordOnlyIndex >= 0) {
 		parametersCopy.splice(firstKeywordOnlyIndex, 0, {
 			id: 999_999,

--- a/packages/plugin/src/plugin/python/transformation.ts
+++ b/packages/plugin/src/plugin/python/transformation.ts
@@ -252,7 +252,7 @@ export class DocspecTransformer {
 								: undefined,
 							defaultValue: arg.default_value as string,
 							flags: {
-								isOptional: arg.datatype?.includes('Optional'),
+								isOptional: arg.datatype?.includes('Optional') || arg.default_value === undefined,
 								'keyword-only': arg.type === 'KEYWORD_ONLY',
 							},
 							id: getOID(),


### PR DESCRIPTION
Introduces small fixes to the rendering of function argument "pills" for Python projects.