### PR TITLE
fix: set `optional` flag if there's a default value for function argument

### DIFF
--- a/packages/plugin/src/plugin/python/transformation.ts
+++ b/packages/plugin/src/plugin/python/transformation.ts
@@ -252,7 +252,7 @@ export class DocspecTransformer {
 								: undefined,
 							defaultValue: arg.default_value as string,
 							flags: {
-								isOptional: arg.datatype?.includes('Optional') || arg.default_value === undefined,
+								isOptional: arg.datatype?.includes('Optional') || arg.default_value !== undefined,
 								'keyword-only': arg.type === 'KEYWORD_ONLY',
 							},
 							id: getOID(),


### PR DESCRIPTION
Fixes a logical error from #38 . An existing default argument value means that the argument is `optional`.