### PR TITLE
fix: render symbol inheritance in Python correctly

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -92,6 +92,11 @@ export default function typedocApiPlugin(
 		readmes,
 		removeScopes,
 	} = options;
+
+	if (options.pythonOptions && Object.keys(options.pythonOptions).length > 0) {
+		options.python = true;
+	}
+
 	const isDefaultPluginId = pluginId === DEFAULT_PLUGIN_ID;
 	const versionsMetadata = readVersionsMetadata(context, options);
 	const versionsDocsDir = getVersionedDocsDirPath(context.siteDir, pluginId);

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -198,6 +198,7 @@ export function addMetadataToReflections(
 	project: JSONOutput.DeclarationReflection,
 	packageSlug: string,
 	urlPrefix: string,
+	options: DocusaurusPluginTypeDocApiOptions,
 ): TSDDeclarationReflection {
 	const permalink = `/${joinUrl(urlPrefix, packageSlug)}`;
 
@@ -210,7 +211,7 @@ export function addMetadataToReflections(
 			const childPermalink = permalink + childSlug;
 
 			// We need to go another level deeper and only use fragments
-			if (child.kind === ReflectionKind.Namespace && child.children) {
+			if ((child.kind === ReflectionKind.Namespace || options.python) && child.children) {
 				child.children = child.children.map((grandChild) => ({
 					...grandChild,
 					permalink: normalizeUrl([`${childPermalink}#${grandChild.name}`]),
@@ -461,7 +462,7 @@ export function flattenAndGroupPackages(
 
 				// Add metadata to package and children reflections
 				const urlSlug = getPackageSlug(cfg, importPath, isSinglePackage);
-				const reflection = addMetadataToReflections(mod, urlSlug, urlPrefix);
+				const reflection = addMetadataToReflections(mod, urlSlug, urlPrefix, options);
 				const existingEntry = packages[cfg.packagePath].entryPoints.find(
 					(ep) => ep.urlSlug === urlSlug,
 				);

--- a/packages/plugin/src/plugin/python/inheritance.ts
+++ b/packages/plugin/src/plugin/python/inheritance.ts
@@ -82,7 +82,7 @@ export class InheritanceGraph {
 		];
 	
 		for (const inheritedChild of ancestor.children ?? []) {
-			const ownChild = descendant.children?.find((x) => x.name === inheritedChild.name);
+			let ownChild = descendant.children?.find((x) => x.name === inheritedChild.name);
 	
 			if (!ownChild) {
 				const childId = getOID();
@@ -105,7 +105,7 @@ export class InheritanceGraph {
 					});
 				}
 	
-				const newChild = {
+				ownChild = {
 					...inheritedChild,
 					id: childId,
 					inheritedFrom: inheritedChild.inheritedFrom ?? {
@@ -115,18 +115,7 @@ export class InheritanceGraph {
 					},
 				};
 
-				if (newChild.kindString === 'Method') {
-					newChild.signatures = newChild.signatures?.map((sig) => ({
-						...sig,
-						inheritedFrom: inheritedChild.inheritedFrom ??{
-							name: `${ancestor.name}.${inheritedChild.name}`,
-							target: inheritedChild.id,
-							type: 'reference',
-						}
-					}));
-				}
-
-				descendant.children.push(newChild);
+				descendant.children.push(ownChild);
 			} else if (!ownChild.comment?.summary?.[0]?.text) {
 				ownChild.inheritedFrom = {
 					name: `${ancestor.name}.${inheritedChild.name}`,
@@ -140,6 +129,13 @@ export class InheritanceGraph {
 						ownChild[key as keyof typeof ownChild] = inheritedChild[key as keyof typeof inheritedChild];
 					}
 				}
+			}
+
+			if (ownChild.kindString === 'Method') {
+				ownChild.signatures = ownChild.signatures?.map((sig) => ({
+					...sig,
+					inheritedFrom: ownChild.inheritedFrom,
+				}));
 			}
 		}
 

--- a/packages/plugin/src/plugin/python/inheritance.ts
+++ b/packages/plugin/src/plugin/python/inheritance.ts
@@ -116,15 +116,18 @@ export class InheritanceGraph {
 				};
 
 				descendant.children.push(ownChild);
-			} else if (!ownChild.comment?.summary?.[0]?.text) {
-				ownChild.inheritedFrom = {
+			} else {
+				ownChild.overwrites = {
 					name: `${ancestor.name}.${inheritedChild.name}`,
 					target: inheritedChild.id,
 					type: 'reference',
 				};
-	
+			}
+			
+			
+			if (!ownChild.comment?.summary?.[0]?.text) {
 				for (const key of Object.keys(inheritedChild)) {
-					if (key !== 'id' && key !== 'inheritedFrom') {
+					if (!['id','inheritedFrom','overwrites'].includes(key)) {
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 						ownChild[key as keyof typeof ownChild] = inheritedChild[key as keyof typeof inheritedChild];
 					}
@@ -135,6 +138,7 @@ export class InheritanceGraph {
 				ownChild.signatures = ownChild.signatures?.map((sig) => ({
 					...sig,
 					inheritedFrom: ownChild.inheritedFrom,
+					overwrites: ownChild.overwrites,
 				}));
 			}
 		}

--- a/packages/plugin/src/plugin/python/types.ts
+++ b/packages/plugin/src/plugin/python/types.ts
@@ -19,6 +19,11 @@ export interface TypeDocObject {
 		target: OID;
 		name: string;
 	};
+	overwrites?: {
+		type: string;
+		target: OID;
+		name: string;
+	};
 	comment?: {
 		summary: { text: string; kind: 'text' }[];
 		blockTags?: { tag: string; content: any[] }[];


### PR DESCRIPTION
Fixes the missing `Inherited from Foo.bar` message for inherited symbols. Adds Python support for the `overwrites` property for overridden inherited symbols.