### PR TITLE
 fix(python): correct `sources` on inherited symbol override

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/plugin/python/inheritance.ts
+++ b/packages/plugin/src/plugin/python/inheritance.ts
@@ -123,11 +123,11 @@ export class InheritanceGraph {
 					type: 'reference',
 				};
 			}
-			
+
 			
 			if (!ownChild.comment?.summary?.[0]?.text) {
 				for (const key of Object.keys(inheritedChild)) {
-					if (!['id','inheritedFrom','overwrites'].includes(key)) {
+					if (!['id','inheritedFrom','overwrites','sources'].includes(key)) {
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 						ownChild[key as keyof typeof ownChild] = inheritedChild[key as keyof typeof inheritedChild];
 					}

--- a/playground/python/src/foo.py
+++ b/playground/python/src/foo.py
@@ -32,7 +32,4 @@ class Foo(BarBarBar, Generic[T]):
         print("bar", param)
 
     def foo(self, param: str, param2: int = 0, **kwargs: Unpack[FooFooArguments]):
-        """
-        The foo method of the FOO class, prints "foo".
-        """
         print("foo")


### PR DESCRIPTION
The "view source code" button now points to the correct location, even with undocumented (overridden) inherited symbols