### PR TITLE
fix: internal Python tooling fixes, better `TypeAlias` resolving

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/components/Index.tsx
+++ b/packages/plugin/src/components/Index.tsx
@@ -14,7 +14,8 @@ function IndexChild({ id }: IndexChildProps) {
 	const reflection = useRequiredReflection(id);
 
 	return (
-		<li>
+		// eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+		<li style={{ marginTop: '0px', marginBottom: '4px' }}>
 			<Link className="tsd-kind-icon" to={reflection.permalink ?? `#${reflection.name}`}>
 				<Icon reflection={reflection} />
 				{escapeMdx(reflection.name)}

--- a/packages/plugin/src/plugin/python/transformation.ts
+++ b/packages/plugin/src/plugin/python/transformation.ts
@@ -166,16 +166,23 @@ export class DocspecTransformer {
 		for (const sig of signatures) {
 			const unpackedParams: TypeDocObject[] = [];
 			for (const param of sig.parameters ?? []) {
-				if (param.type.type === 'literal' || param.type.type === 'reference' && param.type?.name !== 'Unpack') {
+				if (param.type.type !== 'reference' || param.type?.name !== 'Unpack') {
 					unpackedParams.push(param);
 					// eslint-disable-next-line no-continue
 					continue;
 				}
-
-				const typedDict = this.symbolIdTracker.getTypeDocById((param.type.typeArguments as { target: number }[])[0].target);
+		  
+				const typedDict = this.symbolIdTracker.getTypeDocById(
+					(
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					param.type.typeArguments[0]?.target
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+					?? this.symbolIdTracker.getIdByName(param.type.typeArguments[0]?.name)
+					) as number
+				);
 
 				unpackedParams.push(
-					...typedDict.children.map((x) => ({...x, flags: { 'keyword-only': true, optional: true } })),
+					...(typedDict?.children.map((x) => ({...x, flags: { 'keyword-only': true, optional: true } })) ?? [])
 				)
 			}
 

--- a/packages/plugin/src/plugin/python/type-parsing/index.ts
+++ b/packages/plugin/src/plugin/python/type-parsing/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import childProcess from 'child_process';
 import fs from 'fs';
 import path from 'path';

--- a/packages/plugin/src/plugin/python/type-parsing/index.ts
+++ b/packages/plugin/src/plugin/python/type-parsing/index.ts
@@ -70,6 +70,8 @@ export class PythonTypeResolver {
 			TypeDocType
 		>;
 
+		this.applyAliases(parsedTypes);
+
 		for (const originalType of this.typedocTypes) {
 			if (originalType.type === 'reference') {
 				// The verbatim name of the type will always be in `parsedTypes`.
@@ -92,5 +94,16 @@ export class PythonTypeResolver {
 	 */
 	getBaseType(type: string): string {
 		return type?.replace(/Optional\[(.*)]/g, '$1').split('[')[0];
+	}
+
+	private applyAliases(obj: Record<string, Record<string, any> | { name: string }>) {
+		for (const key of Object.keys(obj)) {
+			if (obj[key]?.name && this.aliases[obj[key]?.name]) {
+				obj[key].name = this.aliases[obj[key]?.name];
+			}
+			if (typeof obj[key] === 'object' && obj[key] !== null) {
+				this.applyAliases(obj[key] as any);
+			}
+		}
 	}
 }

--- a/playground/python/src/foo.py
+++ b/playground/python/src/foo.py
@@ -35,13 +35,13 @@ class Foo(BarBarBar, Generic[T]):
         """
         print("Foo")
 
-    def bar(self, caps: Capitalization):
+    def bar(self, caps: Capitalization | None):
         """
         The bar method of the foo class, prints "bar".
         """
         print("bar")
 
-    def bar_param(self, params: int, **kwargs: Unpack[RandomKwargs]):
+    def bar_param(self, params: int, **kwargs: Unpack[RandomKwargs[GenericParameter]]):
         """
         The bar method of the foo class, prints "bar" and the given parameter.
 


### PR DESCRIPTION
Fixes blocking errors from the previous release and improves the `TypeAlias` resolution (in `Union` / generic types et al.)