### PR TITLE
fix: reproducible versioning (relative `packageRoot`)

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",


### PR DESCRIPTION
Fixes problems with failing version builds in CI/CD. `packageRoot` is now stored as relative to `siteDir` (and expanded at run time), so versioned builds are reproducible under different users / systems. 