### PR TITLE
fix: render generic parameters on functions correctly

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docusaurus-plugin-typedoc-api",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "description": "Docusaurus plugin that provides source code API documentation powered by TypeDoc. ",
   "keywords": [
     "docusaurus",

--- a/packages/plugin/src/components/MemberSignatureTitle.tsx
+++ b/packages/plugin/src/components/MemberSignatureTitle.tsx
@@ -46,7 +46,7 @@ export function MemberSignatureTitle({ useArrow, hideName, sig, hasMultipleSigna
 				</>
 			) : null}
 
-			<TypeParametersGeneric params={sig.typeParameter} />
+			<TypeParametersGeneric params={sig.typeParameters ?? sig.typeParameter} />
 
 			<span className="tsd-signature-symbol">(</span>
 

--- a/playground/js/src/bar.ts
+++ b/playground/js/src/bar.ts
@@ -1,10 +1,10 @@
-export interface BarOptions {
+export interface BarOptions<NameType extends string> {
 	/**
 	 * The name of the `Bar` instance.
 	 *
 	 * @default 'Karl'
 	 */
-	name: string;
+	name: NameType;
 	/**
 	 * The age of the `Bar` instance.
 	 *
@@ -29,7 +29,7 @@ export interface BarOptions {
  * This is a simple class called `Bar`
  */
 export class Bar {
-	private constructor(options: BarOptions) {
+	private constructor() {
 		// do nothing
 	}
 
@@ -39,7 +39,7 @@ export class Bar {
 	 * @param {BarOptions} options
 	 * @returns {Bar}
 	 */
-	static create(options: BarOptions = {} as BarOptions): Bar {
-		return new Bar(options);
+	static create<TypeParamName extends string = 'Karl'>(options: BarOptions<TypeParamName> = {} as BarOptions<TypeParamName>): Bar {
+		return new Bar();
 	}
 }


### PR DESCRIPTION
Accounts for typedoc's `sig.typeParameters` vs `sig.typeParameter` change.