### PR TITLE
chore: fix `playground/website` instance

### DIFF
--- a/playground/website/src/theme/Root.js
+++ b/playground/website/src/theme/Root.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TitleFormatterProvider } from '@docusaurus/theme-common/internal';
+import {
+	DocsPreferredVersionContextProvider,
+	DocsVersionProvider,
+} from '@docusaurus/plugin-content-docs/client';
+
+// Default implementation, that you can customize
+export default function Root({ children }) {
+	return (
+		<DocsVersionProvider
+			version={{
+				badge: false,
+				banner: 'unreleased',
+				docs: [],
+			}}
+		>
+			<DocsPreferredVersionContextProvider>
+				<TitleFormatterProvider formatter={() => 'Apify Playground'}>
+					{children}
+				</TitleFormatterProvider>
+			</DocsPreferredVersionContextProvider>
+		</DocsVersionProvider>
+	);
+}


### PR DESCRIPTION
Fixes issues with the playground website and the new React / Docusaurus version.