### PR TITLE
feat: add `routeBasePath` to global plugin data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,7 @@ Overwriting with relative path from siteDir (${context.siteDir}).`);
 					isLast: x.isLast,
 					path: x.versionPath,
 				})),
+				routeBasePath: options.routeBasePath ?? 'api',
 			} as GlobalData);
 
 			const docs: PropVersionDocs = {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface DocusaurusPluginTypeDocApiOptions
 
 export interface GlobalData {
 	isPython: boolean;
+	routeBasePath: string;
 }
 
 // CONFIG


### PR DESCRIPTION
Forwards the `routeBasePath` option to the global plugin data so it can be accessed by other plugins. 