### PR TITLE
fix: stabilize python module order in typedoc snapshots

### DIFF
--- a/src/plugin/python/transformation.ts
+++ b/src/plugin/python/transformation.ts
@@ -150,8 +150,12 @@ export class DocspecTransformer {
 			docspecModules as unknown as { name: string },
 		);
 
+		// Sort modules by name so the sequential IDs assigned by `SymbolIdTracker` are deterministic across
+        // runs (`PythonLoader` traversal order is filesystem-dependent and reshuffles IDs across CI machines).
+		const sortedModules = [...docspecModules].sort((a, b) => a.name.localeCompare(b.name));
+
 		// Convert all the modules, store them in the root object
-		for (const module of docspecModules) {
+		for (const module of sortedModules) {
 			this.walkAndTransform({
 				currentDocspecNode: module,
 				moduleName: module.name,


### PR DESCRIPTION
## Summary

In `DocspecTransformer.transform()` the sequential IDs assigned by `SymbolIdTracker` depend on the order `pydoc-markdown`'s `PythonLoader` yields modules. That order is filesystem-walk-dependent, so different CI machines produce different module orders and reshuffle every `id` and `target` reference in the generated JSON.

Sort the docspec modules by name once at the start of `transform()` so IDs are assigned deterministically. Per-module member order (which already follows source-code declaration order) is unchanged.

In consumer projects that commit versioned typedoc snapshots (e.g. `crawlee-python`'s `website/versioned_docs/version-*/api-typedoc.json`), this was producing ~100k-line no-op diffs in every release commit.

## Verification

Linked the local plugin into `crawlee-python/website` and ran `pnpm exec docusaurus api:version 99.1` twice on the same HEAD — output is byte-identical. `yarn build`, `yarn type`, and `yarn lint` are clean.