### PR TITLE
fix: surface generate_ast.py failures with a clear error

### DIFF
--- a/src/plugin/python/index.ts
+++ b/src/plugin/python/index.ts
@@ -31,7 +31,13 @@ export function processPythonDocs({
 	]);
 
 	if (out.error) {
-		throw new Error(out.error.message);
+		throw new Error(`Failed to spawn the generate_ast.py script: ${out.error.message}`);
+	}
+
+	if (out.status !== 0) {
+		throw new Error(
+			`The generate_ast.py script failed with exit code ${out.status}:\n${out.stderr.toString()}`,
+		);
 	}
 
 	const moduleShortcuts = JSON.parse(fs.readFileSync(moduleShortcutsPath, 'utf8')) as Record<


### PR DESCRIPTION
## Summary

`processPythonDocs` only checks `spawnSync().error`, which is set when the spawn itself fails — a non-zero exit of `generate_ast.py` (e.g. `pydoc-markdown` not importable by the resolved `python`) went completely unnoticed. The plugin then crashed later with a confusing `ENOENT: pydoc-markdown-dump.json`, hiding the real cause.

This is exactly what made the broken `Version docs` CI job in apify/apify-sdk-python (failed 3.4.0/3.4.1 doc releases) hard to diagnose — see apify/apify-sdk-python#928 for the workflow-side fix.

Now the exit code is checked and the script's stderr is included in the thrown error:

```
[ERROR] Error: The generate_ast.py script failed with exit code 1:
ModuleNotFoundError: No module named pydoc_markdown
```

Verified by building the plugin, dropping the compiled output into the SDK website's `node_modules`, and running `docusaurus api:version` with a stub `python` that exits 1.