### PR TITLE
feat: render an "Added in" pill for the @added_in tag

### DIFF
--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -32,6 +32,18 @@ export function displayPartsToMarkdown(parts: JSONOutput.CommentDisplayPart[]): 
 		.join('');
 }
 
+const ADDED_IN_TAG = '@added_in';
+
+function getAddedInVersion(comment: JSONOutput.Comment): string | null {
+	const tag = comment.blockTags?.find((blockTag) => blockTag.tag === ADDED_IN_TAG);
+
+	if (!tag) {
+		return null;
+	}
+
+	return displayPartsToMarkdown(tag.content).trim() || null;
+}
+
 export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 	if (!comment || !hasComment(comment)) {
 		return null;
@@ -40,17 +52,23 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 	// Hide custom tags.
 	hideTags.push('@reference');
 
+	const addedIn = getAddedInVersion(comment);
+
 	const blockTags =
 		comment.blockTags?.filter((tag) => {
 			if (hideTags.includes(tag.tag)) {
 				return false;
 			}
 
-			return tag.tag !== '@default';
+			return tag.tag !== '@default' && tag.tag !== ADDED_IN_TAG;
 		}) ?? [];
 
 	return (
 		<div className={`tsd-comment tsd-typography ${root ? 'tsd-comment-root' : ''}`}>
+			{addedIn && (
+				<span className="badge badge--secondary tsd-added-in">Added in: {addedIn}</span>
+			)}
+
 			{!!comment.summary && (
 				<div className="lead">
 					<Markdown content={displayPartsToMarkdown(comment.summary)} />

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -196,6 +196,11 @@ html[data-theme='light'] .tsd-panel-content {
 	margin-bottom: var(--tsd-spacing-vertical-full);
 }
 
+.tsd-added-in {
+	display: inline-block;
+	margin-bottom: var(--tsd-spacing-vertical);
+}
+
 /* SOURCES */
 
 .tsd-sources,

--- a/src/plugin/data.ts
+++ b/src/plugin/data.ts
@@ -120,6 +120,8 @@ export async function generateJson(
 					'@apilink',
 					'@doclink',
 				] as `@${string}`[],
+				// Recognize the @added_in tag (rendered as a pill) on top of the defaults.
+				blockTags: [...TypeDoc.OptionDefaults.blockTags, '@added_in'] as `@${string}`[],
 				...options.typedocOptions,
 				// Control how config and packages are detected
 				tsconfig,


### PR DESCRIPTION
Adds support for a custom `@added_in <version>` JSDoc block tag and renders it as a pill (`Added in: x.y.z`) at the top of a member's comment.

`@added_in` is appended to TypeDoc's default `blockTags` so it's recognized without a warning and without dropping the built-in tags. `Comment` extracts the tag, renders it using the existing Infima `badge` classes, and excludes it from the raw block-tag list so it isn't shown twice. Pill-only comments still render correctly.

The tag itself is populated in source by a separate annotation script (per-repo), so this only needs the plugin to recognize and display it.