### PR TITLE
fix: add bottom spacing to the top-level `@since` tag

### DIFF
--- a/src/components/Reflection.tsx
+++ b/src/components/Reflection.tsx
@@ -34,7 +34,7 @@ export function Reflection({ reflection }: ReflectionProps) {
 			{hasComment(reflection.comment) && <Comment root comment={reflection.comment} />}
 
 			{sinceContent && (
-				<div className="tsd-comment-since">
+				<div className="tsd-comment-since tsd-comment-since-root">
 					<Markdown content={displayPartsToMarkdown(sinceContent)} />
 				</div>
 			)}

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -199,6 +199,12 @@ html[data-theme='light'] .tsd-panel-content {
 	border-top: 1px solid rgba(0, 0, 0, 0.05);
 }
 
+/* Top-level symbols render the tag inline above other sections, so it needs a
+   bottom margin to sit evenly; member tags close out a panel and don't. */
+.tsd-comment-since-root {
+	margin-bottom: 1em;
+}
+
 .tsd-comment-root {
 	margin-top: 0;
 	margin-bottom: var(--tsd-spacing-vertical-full);


### PR DESCRIPTION
Updates CSS styling for the top-level `@since` tags.