### PR TITLE
fix: drop CrossrefProcessor that corrupts URL fragments in docstrings

### DIFF
--- a/python-scripts/docspec-gen/generate_ast.py
+++ b/python-scripts/docspec-gen/generate_ast.py
@@ -48,13 +48,6 @@ def main():
     filter.init(context)
     google.init(context)
 
-    # NOTE: pydoc-markdown's CrossrefProcessor is intentionally omitted. It is always run with
-    # resolver=None here, so it can never turn a `#ref` into an actual link — it only falls back to
-    # wrapping the ref in backticks. Worse, its regex matches any `#word` preceded by a non-word
-    # char (e.g. the `/#` in `.../dockerfile_best-practices/#leverage-build-cache`), corrupting URL
-    # fragments into broken links like ``...best-practices/`leverage`-build-cache``. The Apify
-    # docstrings don't use `#ref` cross-references, so dropping it is pure win (and matches the
-    # griffe-based extractor, which doesn't run it either).
     processors = [filter, google]
 
     dump = []

--- a/python-scripts/docspec-gen/generate_ast.py
+++ b/python-scripts/docspec-gen/generate_ast.py
@@ -7,7 +7,6 @@ This script generates an AST from the Python source code in the `src` directory 
 from pydoc_markdown.interfaces import Context
 from pydoc_markdown.contrib.loaders.python import PythonLoader
 from pydoc_markdown.contrib.processors.filter import FilterProcessor
-from pydoc_markdown.contrib.processors.crossref import CrossrefProcessor
 from google_docstring_processor import ApifyGoogleProcessor
 from docspec import dump_module
 
@@ -43,15 +42,20 @@ def main():
         documented_only=False,
         skip_empty_modules=False,
     )
-    crossref = CrossrefProcessor()
     google = ApifyGoogleProcessor()
 
     loader.init(context)
     filter.init(context)
     google.init(context)
-    crossref.init(context)
 
-    processors = [filter, google, crossref]
+    # NOTE: pydoc-markdown's CrossrefProcessor is intentionally omitted. It is always run with
+    # resolver=None here, so it can never turn a `#ref` into an actual link — it only falls back to
+    # wrapping the ref in backticks. Worse, its regex matches any `#word` preceded by a non-word
+    # char (e.g. the `/#` in `.../dockerfile_best-practices/#leverage-build-cache`), corrupting URL
+    # fragments into broken links like ``...best-practices/`leverage`-build-cache``. The Apify
+    # docstrings don't use `#ref` cross-references, so dropping it is pure win (and matches the
+    # griffe-based extractor, which doesn't run it either).
+    processors = [filter, google]
 
     dump = []
 


### PR DESCRIPTION
pydoc-markdown's `CrossrefProcessor` is run with `resolver=None` in `generate_ast.py`, so it can never resolve a `#ref` into a real link — it only falls back to wrapping the ref in backticks. Its regex `\B#([\w\d._]+)` also matches any `#word` preceded by a non-word char, so URL fragments like `.../dockerfile_best-practices/#leverage-build-cache` (the `/#` sequence) get corrupted into broken links such as ``...best-practices/`leverage`-build-cache``.

The Apify docstrings don't use `#ref` cross-references, so this drops `CrossrefProcessor` from the processor list — it brought no benefit (never produced links) and only corrupted fragments. This also matches the griffe-based extractor, which doesn't run it either.

Verified by running the patched `generate_ast.py` against apify-client-python: the generated AST now contains `#leverage-build-cache` intact.