### PR TITLE
chore: normalize package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:apify/docusaurus-plugin-typedoc-api.git"
+    "url": "git+https://github.com/apify/docusaurus-plugin-typedoc-api.git"
   },
   "author": "Miles Johnson, Apify Technologies",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- normalize the package `repository.url` from the SSH-style `git@github.com:...` form to `git+https://github.com/apify/docusaurus-plugin-typedoc-api.git`
- leave runtime code, dependencies, package versioning, and published entry points unchanged

## Validation

- `yarn install --immutable --mode=skip-build`
- package metadata assertion for the normalized repository URL
- `yarn type`
- `yarn build`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Note: `yarn install` reports existing peer dependency warnings around the current TypeScript/Typedoc range; this PR does not change dependencies.
