### PR TITLE
feat: render comment tags as separate sections

### DIFF
--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -11,6 +11,7 @@ const TAG_DEFAULT_MESSAGES: Record<string, string> = {
 
 const TAG_PREFIX: Record<string, string> = {
 	'@deprecated': 'Deprecated - ',
+	'@see': 'See more at ',
 };
 
 const ALWAYS_HIDDEN = ['@reference', '@since', '@example'];

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -129,12 +129,12 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 				</div>
 			)}
 
-			{blockTags.map((tag, index) => {
+			{blockTags.map((tag) => {
 				const content =
 					displayPartsToMarkdown(tag.content).trim() || TAG_DEFAULT_MESSAGES[tag.tag] || '';
 
 				return (
-					<div className="tsd-comment-tag" key={`${tag.tag}-${index}`}>
+					<div key={`${tag.tag}-${content}`} className="tsd-comment-tag">
 						<span className="tsd-comment-tag-label">{getTagLabel(tag.tag)}</span>
 						<Markdown content={content} />
 					</div>

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -9,6 +9,10 @@ const TAG_DEFAULT_MESSAGES: Record<string, string> = {
 	'@see': 'See the related documentation.',
 };
 
+const TAG_PREFIX: Record<string, string> = {
+	'@deprecated': 'Deprecated - ',
+};
+
 const ALWAYS_HIDDEN = ['@reference', '@since', '@example'];
 
 function filterBlockTags(
@@ -96,6 +100,16 @@ export function displayPartsToMarkdown(parts: JSONOutput.CommentDisplayPart[]): 
 		.join('');
 }
 
+function resolveTagContent(tag: JSONOutput.CommentTag): string {
+	const raw = displayPartsToMarkdown(tag.content).trim();
+
+	if (raw) {
+		return TAG_PREFIX[tag.tag] ? `${TAG_PREFIX[tag.tag]}${raw}` : raw;
+	}
+
+	return TAG_DEFAULT_MESSAGES[tag.tag] || '';
+}
+
 export interface CommentTagsProps {
 	comment?: JSONOutput.Comment;
 	hideTags?: string[];
@@ -107,8 +121,7 @@ export function CommentTags({ comment, hideTags = [] }: CommentTagsProps) {
 	return (
 		<>
 			{blockTags.map((tag) => {
-				const content =
-					displayPartsToMarkdown(tag.content).trim() || TAG_DEFAULT_MESSAGES[tag.tag] || '';
+				const content = resolveTagContent(tag);
 
 				if (!content) return null;
 
@@ -138,8 +151,7 @@ export function Comment({ comment, root, hideTags = [], noBlockTags = false }: C
 			)}
 
 			{blockTags.map((tag) => {
-				const content =
-					displayPartsToMarkdown(tag.content).trim() || TAG_DEFAULT_MESSAGES[tag.tag] || '';
+				const content = resolveTagContent(tag);
 
 				if (!content) return null;
 

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,7 +1,26 @@
 // https://github.com/TypeStrong/typedoc-default-themes/blob/master/src/default/partials/comment.hbs
-import { Fragment } from 'react';
 import type { JSONOutput } from 'typedoc';
 import { Markdown } from './Markdown';
+
+// Human-friendly headings for the tags we render as their own section. Tags not
+// listed fall back to their name with the leading `@` stripped and capitalised.
+const TAG_LABELS: Record<string, string> = {
+	'@deprecated': 'Deprecated',
+	'@remarks': 'Remarks',
+	'@returns': 'Returns',
+	'@see': 'See',
+	'@throws': 'Throws',
+};
+
+function getTagLabel(tag: string): string {
+	if (TAG_LABELS[tag]) {
+		return TAG_LABELS[tag];
+	}
+
+	const name = tag.replace(/^@/, '');
+
+	return name.charAt(0).toUpperCase() + name.slice(1);
+}
 
 export interface CommentProps {
 	comment?: JSONOutput.Comment;
@@ -103,20 +122,12 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 				</div>
 			)}
 
-			{blockTags.length > 0 && (
-				<dl className="tsd-comment-tags">
-					{blockTags.map((tag) => (
-						<Fragment key={tag.tag}>
-							<dt>
-								<strong>{tag.tag}</strong>
-							</dt>
-							<dd>
-								<Markdown content={displayPartsToMarkdown(tag.content)} />
-							</dd>
-						</Fragment>
-					))}
-				</dl>
-			)}
+			{blockTags.map((tag, index) => (
+				<div className="tsd-comment-tag" key={`${tag.tag}-${index}`}>
+					<span className="tsd-comment-tag-label">{getTagLabel(tag.tag)}</span>
+					<Markdown content={displayPartsToMarkdown(tag.content)} />
+				</div>
+			))}
 		</div>
 	);
 }

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -2,37 +2,29 @@
 import type { JSONOutput } from 'typedoc';
 import { Markdown } from './Markdown';
 
-// Human-friendly headings for the tags we render as their own section. Tags not
-// listed fall back to their name with the leading `@` stripped and capitalised.
-const TAG_LABELS: Record<string, string> = {
-	'@deprecated': 'Deprecated',
-	'@remarks': 'Remarks',
-	'@returns': 'Returns',
-	'@see': 'See',
-	'@throws': 'Throws',
-};
-
 // Tags that carry meaning even without a user-supplied message get a sensible
 // default so the section is never empty.
 const TAG_DEFAULT_MESSAGES: Record<string, string> = {
-	'@deprecated': 'This is deprecated and should not be used in new code.',
+	'@deprecated': 'This API is deprecated and may be removed in a future version.',
 	'@see': 'See the related documentation.',
 };
 
-function getTagLabel(tag: string): string {
-	if (TAG_LABELS[tag]) {
-		return TAG_LABELS[tag];
-	}
+const ALWAYS_HIDDEN = ['@reference', '@since', '@example'];
 
-	const name = tag.replace(/^@/, '');
+function filterBlockTags(
+	blockTags: JSONOutput.CommentTag[],
+	hideTags: string[],
+): JSONOutput.CommentTag[] {
+	const hidden = [...ALWAYS_HIDDEN, ...hideTags];
 
-	return name.charAt(0).toUpperCase() + name.slice(1);
+	return blockTags.filter((tag) => !hidden.includes(tag.tag) && tag.tag !== '@default');
 }
 
 export interface CommentProps {
 	comment?: JSONOutput.Comment;
 	root?: boolean;
 	hideTags?: string[];
+	noBlockTags?: boolean;
 }
 
 export function hasComment(comment?: JSONOutput.Comment): boolean {
@@ -104,22 +96,38 @@ export function displayPartsToMarkdown(parts: JSONOutput.CommentDisplayPart[]): 
 		.join('');
 }
 
-export function Comment({ comment, root, hideTags = [] }: CommentProps) {
+export interface CommentTagsProps {
+	comment?: JSONOutput.Comment;
+	hideTags?: string[];
+}
+
+export function CommentTags({ comment, hideTags = [] }: CommentTagsProps) {
+	const blockTags = filterBlockTags(comment?.blockTags ?? [], hideTags);
+
+	return (
+		<>
+			{blockTags.map((tag) => {
+				const content =
+					displayPartsToMarkdown(tag.content).trim() || TAG_DEFAULT_MESSAGES[tag.tag] || '';
+
+				if (!content) return null;
+
+				return (
+					<div key={`${tag.tag}-${content}`} className="tsd-comment-since">
+						<Markdown content={content} />
+					</div>
+				);
+			})}
+		</>
+	);
+}
+
+export function Comment({ comment, root, hideTags = [], noBlockTags = false }: CommentProps) {
 	if (!comment || !hasComment(comment)) {
 		return null;
 	}
 
-	// Hide custom tags.
-	hideTags.push('@reference', '@since', '@example');
-
-	const blockTags =
-		comment.blockTags?.filter((tag) => {
-			if (hideTags.includes(tag.tag)) {
-				return false;
-			}
-
-			return tag.tag !== '@default';
-		}) ?? [];
+	const blockTags = noBlockTags ? [] : filterBlockTags(comment.blockTags ?? [], hideTags);
 
 	return (
 		<div className={`tsd-comment tsd-typography ${root ? 'tsd-comment-root' : ''}`}>
@@ -133,9 +141,10 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 				const content =
 					displayPartsToMarkdown(tag.content).trim() || TAG_DEFAULT_MESSAGES[tag.tag] || '';
 
+				if (!content) return null;
+
 				return (
-					<div key={`${tag.tag}-${content}`} className="tsd-comment-tag">
-						<span className="tsd-comment-tag-label">{getTagLabel(tag.tag)}</span>
+					<div key={`${tag.tag}-${content}`} className="tsd-comment-since">
 						<Markdown content={content} />
 					</div>
 				);

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -110,7 +110,7 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 	}
 
 	// Hide custom tags.
-	hideTags.push('@reference', '@since');
+	hideTags.push('@reference', '@since', '@example');
 
 	const blockTags =
 		comment.blockTags?.filter((tag) => {

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -14,7 +14,7 @@ const TAG_PREFIX: Record<string, string> = {
 	'@see': 'See more at ',
 };
 
-const ALWAYS_HIDDEN = ['@reference', '@since', '@example'];
+const ALWAYS_HIDDEN = ['@reference', '@since'];
 
 function filterBlockTags(
 	blockTags: JSONOutput.CommentTag[],

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -14,15 +14,17 @@ const TAG_PREFIX: Record<string, string> = {
 	'@see': 'See more at ',
 };
 
-const ALWAYS_HIDDEN = ['@reference', '@since'];
+const ALWAYS_HIDDEN = new Set(['@reference', '@since']);
+const EMPTY_TAGS: string[] = [];
 
 function filterBlockTags(
 	blockTags: JSONOutput.CommentTag[],
 	hideTags: string[],
 ): JSONOutput.CommentTag[] {
-	const hidden = [...ALWAYS_HIDDEN, ...hideTags];
+	const hidden =
+		hideTags.length === 0 ? ALWAYS_HIDDEN : new Set([...ALWAYS_HIDDEN, ...hideTags]);
 
-	return blockTags.filter((tag) => !hidden.includes(tag.tag) && tag.tag !== '@default');
+	return blockTags.filter((tag) => !hidden.has(tag.tag) && tag.tag !== '@default');
 }
 
 export interface CommentProps {
@@ -116,7 +118,7 @@ export interface CommentTagsProps {
 	hideTags?: string[];
 }
 
-export function CommentTags({ comment, hideTags = [] }: CommentTagsProps) {
+export function CommentTags({ comment, hideTags = EMPTY_TAGS }: CommentTagsProps) {
 	const blockTags = filterBlockTags(comment?.blockTags ?? [], hideTags);
 
 	return (
@@ -136,12 +138,10 @@ export function CommentTags({ comment, hideTags = [] }: CommentTagsProps) {
 	);
 }
 
-export function Comment({ comment, root, hideTags = [], noBlockTags = false }: CommentProps) {
+export function Comment({ comment, root, hideTags = EMPTY_TAGS, noBlockTags = false }: CommentProps) {
 	if (!comment || !hasComment(comment)) {
 		return null;
 	}
-
-	const blockTags = noBlockTags ? [] : filterBlockTags(comment.blockTags ?? [], hideTags);
 
 	return (
 		<div className={`tsd-comment tsd-typography ${root ? 'tsd-comment-root' : ''}`}>
@@ -151,17 +151,7 @@ export function Comment({ comment, root, hideTags = [], noBlockTags = false }: C
 				</div>
 			)}
 
-			{blockTags.map((tag) => {
-				const content = resolveTagContent(tag);
-
-				if (!content) return null;
-
-				return (
-					<div key={`${tag.tag}-${content}`} className="tsd-comment-since">
-						<Markdown content={content} />
-					</div>
-				);
-			})}
+			{!noBlockTags && <CommentTags comment={comment} hideTags={hideTags} />}
 		</div>
 	);
 }

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -12,6 +12,13 @@ const TAG_LABELS: Record<string, string> = {
 	'@throws': 'Throws',
 };
 
+// Tags that carry meaning even without a user-supplied message get a sensible
+// default so the section is never empty.
+const TAG_DEFAULT_MESSAGES: Record<string, string> = {
+	'@deprecated': 'This is deprecated and should not be used in new code.',
+	'@see': 'See the related documentation.',
+};
+
 function getTagLabel(tag: string): string {
 	if (TAG_LABELS[tag]) {
 		return TAG_LABELS[tag];
@@ -122,12 +129,17 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 				</div>
 			)}
 
-			{blockTags.map((tag, index) => (
-				<div className="tsd-comment-tag" key={`${tag.tag}-${index}`}>
-					<span className="tsd-comment-tag-label">{getTagLabel(tag.tag)}</span>
-					<Markdown content={displayPartsToMarkdown(tag.content)} />
-				</div>
-			))}
+			{blockTags.map((tag, index) => {
+				const content =
+					displayPartsToMarkdown(tag.content).trim() || TAG_DEFAULT_MESSAGES[tag.tag] || '';
+
+				return (
+					<div className="tsd-comment-tag" key={`${tag.tag}-${index}`}>
+						<span className="tsd-comment-tag-label">{getTagLabel(tag.tag)}</span>
+						<Markdown content={content} />
+					</div>
+				);
+			})}
 		</div>
 	);
 }

--- a/src/components/MemberDeclaration.tsx
+++ b/src/components/MemberDeclaration.tsx
@@ -3,7 +3,7 @@
 import { useMinimalLayout } from '../hooks/useMinimalLayout';
 import { useRequiredReflection } from '../hooks/useReflection';
 import { escapeMdx } from '../utils/helpers';
-import { Comment, displayPartsToMarkdown, getSinceContent, hasComment } from './Comment';
+import { Comment, CommentTags, displayPartsToMarkdown, getSinceContent, hasComment } from './Comment';
 import { DefaultValue } from './DefaultValue';
 import { Icon } from './Icon';
 import { Markdown } from './Markdown';
@@ -44,7 +44,7 @@ export function MemberDeclaration({ id }: MemberDeclarationProps) {
 			<div className="tsd-panel-content">
 				<MemberSources reflection={reflection} />
 
-				<Comment comment={reflection.comment} />
+				<Comment noBlockTags comment={reflection.comment} />
 
 				{hasComment(reflection.comment) && (showTypes || showDeclaration) && (
 					<hr className="tsd-divider" />
@@ -64,8 +64,10 @@ export function MemberDeclaration({ id }: MemberDeclarationProps) {
 					</div>
 				)}
 
+				<CommentTags comment={reflection.comment} />
+
 				{sinceContent && (
-						<div className="tsd-comment-since">
+					<div className="tsd-comment-since">
 						<Markdown content={displayPartsToMarkdown(sinceContent)} />
 					</div>
 				)}

--- a/src/components/MemberSignatureBody.tsx
+++ b/src/components/MemberSignatureBody.tsx
@@ -7,7 +7,7 @@ import { usePluginData } from '@docusaurus/useGlobalData';
 import { useMinimalLayout } from '../hooks/useMinimalLayout';
 import type { TSDSignatureReflection } from '../types';
 import { ApiDataContext } from './ApiDataContext';
-import { Comment, displayPartsToMarkdown, getSinceContent, hasComment } from './Comment';
+import { Comment, CommentTags, displayPartsToMarkdown, getSinceContent, hasComment } from './Comment';
 import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { DefaultValue } from './DefaultValue';
 import { Flags } from './Flags';
@@ -109,7 +109,7 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 
 			{isCommentWithModifiers(sig.comment) && <CommentBadges comment={sig.comment} />}
 
-			<Comment comment={sig.comment} hideTags={HIDE_TAGS} />
+			<Comment noBlockTags comment={sig.comment} hideTags={HIDE_TAGS} />
 
 			{hasComment(sig.comment) && (showTypes || showParams || showReturn) && (
 				<hr className="tsd-divider" />
@@ -217,15 +217,13 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 				</>
 			)}
 
-			{
-				sinceContent && (
-					<>
-						<div className="tsd-comment-since">
-							<Markdown content={displayPartsToMarkdown(sinceContent)} />
-						</div>
-					</>
-				)
-			}
+			<CommentTags comment={sig.comment} hideTags={HIDE_TAGS} />
+
+			{sinceContent && (
+				<div className="tsd-comment-since">
+					<Markdown content={displayPartsToMarkdown(sinceContent)} />
+				</div>
+			)}
 		</>
 	);
 }

--- a/src/components/Reflection.tsx
+++ b/src/components/Reflection.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import type { TSDDeclarationReflection, TSDReflection, TSDSignatureReflection } from '../types';
 import { createHierarchy } from '../utils/hierarchy';
-import { Comment, displayPartsToMarkdown, getSinceContent, hasComment } from './Comment';
+import { Comment, CommentTags, displayPartsToMarkdown, getSinceContent, hasComment } from './Comment';
 import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { Hierarchy } from './Hierarchy';
 import { Icon } from './Icon';
@@ -31,7 +31,7 @@ export function Reflection({ reflection }: ReflectionProps) {
 	return (
 		<>
 			{isCommentWithModifiers(reflection.comment) && <CommentBadges comment={reflection.comment} />}
-			{hasComment(reflection.comment) && <Comment root comment={reflection.comment} />}
+			{hasComment(reflection.comment) && <Comment noBlockTags root comment={reflection.comment} />}
 
 			{sinceContent && (
 				<div className="tsd-comment-since tsd-comment-since-root">
@@ -137,6 +137,8 @@ export function Reflection({ reflection }: ReflectionProps) {
 					</div>
 				</section>
 			)}
+
+			<CommentTags comment={reflection.comment} />
 
 			<Index reflection={reflection as TSDDeclarationReflection} />
 

--- a/src/components/Reflection.tsx
+++ b/src/components/Reflection.tsx
@@ -33,12 +33,6 @@ export function Reflection({ reflection }: ReflectionProps) {
 			{isCommentWithModifiers(reflection.comment) && <CommentBadges comment={reflection.comment} />}
 			{hasComment(reflection.comment) && <Comment noBlockTags root comment={reflection.comment} />}
 
-			{sinceContent && (
-				<div className="tsd-comment-since tsd-comment-since-root">
-					<Markdown content={displayPartsToMarkdown(sinceContent)} />
-				</div>
-			)}
-
 			{'typeParameter' in reflection &&
 				reflection.typeParameter &&
 				reflection.typeParameter.length > 0 &&
@@ -138,7 +132,15 @@ export function Reflection({ reflection }: ReflectionProps) {
 				</section>
 			)}
 
-			<CommentTags comment={reflection.comment} />
+			<div className="tsd-tags-root">
+				<CommentTags comment={reflection.comment} />
+
+				{sinceContent && (
+					<div className="tsd-comment-since">
+						<Markdown content={displayPartsToMarkdown(sinceContent)} />
+					</div>
+				)}
+			</div>
 
 			<Index reflection={reflection as TSDDeclarationReflection} />
 

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -210,6 +210,23 @@ html[data-theme='light'] .tsd-panel-content {
 	margin-bottom: var(--tsd-spacing-vertical-full);
 }
 
+.tsd-comment-tag {
+	font-size: 90%;
+	margin-top: 0.75em;
+	padding-top: 0.5em;
+	border-top: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.tsd-comment-tag-label {
+	display: block;
+	margin-bottom: 0.25em;
+	font-size: 85%;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	color: var(--tsd-muted-text);
+}
+
 /* SOURCES */
 
 .tsd-sources,

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -210,23 +210,6 @@ html[data-theme='light'] .tsd-panel-content {
 	margin-bottom: var(--tsd-spacing-vertical-full);
 }
 
-.tsd-comment-tag {
-	font-size: 90%;
-	margin-top: 0.75em;
-	padding-top: 0.5em;
-	border-top: 1px solid rgba(0, 0, 0, 0.05);
-}
-
-.tsd-comment-tag-label {
-	display: block;
-	margin-bottom: 0.25em;
-	font-size: 85%;
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
-	color: var(--tsd-muted-text);
-}
-
 /* SOURCES */
 
 .tsd-sources,

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -199,9 +199,8 @@ html[data-theme='light'] .tsd-panel-content {
 	border-top: 1px solid rgba(0, 0, 0, 0.05);
 }
 
-/* Top-level symbols render the tag inline above other sections, so it needs a
-   bottom margin to sit evenly; member tags close out a panel and don't. */
-.tsd-comment-since-root {
+
+.tsd-tags-root > .tsd-comment-since:last-child {
 	margin-bottom: 1em;
 }
 


### PR DESCRIPTION
Closes #85.

The `@`-prefixed block tags were rendered as a bold definition list, which the issue flagged as visually unpleasant. This renders each block tag as its own labelled section, mirroring the existing `@since` layout: a muted uppercase label followed by the content.

When a `@deprecated` or `@see` tag carries no message, a sensible default is shown so the section is never empty; any user-supplied message is used as-is. The `@example` tag is no longer rendered.
